### PR TITLE
Use www subdomain for Web endpoint

### DIFF
--- a/lib/endpoints.go
+++ b/lib/endpoints.go
@@ -73,7 +73,7 @@ func ResolveServiceEndpoints(baseDomain string) (ServiceEndpoints, error) {
 		Base:    origin(rootHost),
 		API:     origin("api." + rootHost),
 		Meta:    origin("meta." + rootHost),
-		Web:     origin(rootHost),
+		Web:     origin("www." + rootHost),
 		Storage: origin("storage." + rootHost),
 	}, nil
 }

--- a/lib/endpoints_test.go
+++ b/lib/endpoints_test.go
@@ -14,7 +14,7 @@ func TestResolveServiceEndpoints(t *testing.T) {
 			input: "https://bizyair.vip",
 			want: ServiceEndpoints{
 				Base: "https://bizyair.vip", API: "https://api.bizyair.vip", Meta: "https://meta.bizyair.vip",
-				Web: "https://bizyair.vip", Storage: "https://storage.bizyair.vip",
+				Web: "https://www.bizyair.vip", Storage: "https://storage.bizyair.vip",
 			},
 		},
 		{
@@ -22,7 +22,7 @@ func TestResolveServiceEndpoints(t *testing.T) {
 			input: "https://api.bizyair.vip/",
 			want: ServiceEndpoints{
 				Base: "https://bizyair.vip", API: "https://api.bizyair.vip", Meta: "https://meta.bizyair.vip",
-				Web: "https://bizyair.vip", Storage: "https://storage.bizyair.vip",
+				Web: "https://www.bizyair.vip", Storage: "https://storage.bizyair.vip",
 			},
 		},
 		{
@@ -30,7 +30,15 @@ func TestResolveServiceEndpoints(t *testing.T) {
 			input: "https://bizyair.ai",
 			want: ServiceEndpoints{
 				Base: "https://bizyair.ai", API: "https://api.bizyair.ai", Meta: "https://meta.bizyair.ai",
-				Web: "https://bizyair.ai", Storage: "https://storage.bizyair.ai",
+				Web: "https://www.bizyair.ai", Storage: "https://storage.bizyair.ai",
+			},
+		},
+		{
+			name:  "web origin normalizes without duplicating prefix",
+			input: "https://www.bizyair.ai/",
+			want: ServiceEndpoints{
+				Base: "https://bizyair.ai", API: "https://api.bizyair.ai", Meta: "https://meta.bizyair.ai",
+				Web: "https://www.bizyair.ai", Storage: "https://storage.bizyair.ai",
 			},
 		},
 		{
@@ -68,9 +76,9 @@ func TestServiceEndpointURLs(t *testing.T) {
 		"model detail": endpoints.ModelDetailURL(42),
 	}
 	wants := map[string]string{
-		"base models":  "https://bizyair.vip/api/special/community/base_model_types",
-		"my models":    "https://bizyair.vip/community?path=my",
-		"model detail": "https://bizyair.vip/community/models/my/42",
+		"base models":  "https://www.bizyair.vip/api/special/community/base_model_types",
+		"my models":    "https://www.bizyair.vip/community?path=my",
+		"model detail": "https://www.bizyair.vip/community/models/my/42",
 	}
 	for name, got := range tests {
 		if got != wants[name] {


### PR DESCRIPTION
Update lib/endpoints.go so the Web endpoint uses the "www" subdomain (origin("www." + rootHost)) instead of the bare root host. This aligns the Web endpoint with other services that use subdomains (api., meta., storage.) and avoids relying on the root host for the web origin.