### PR TITLE
Hotfix/upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ go.work.sum
 .env
 .idea
 .vscode
+
+# macOS
+.DS_Store
 temp
 .exe
 execs

--- a/lib/checkpoint.go
+++ b/lib/checkpoint.go
@@ -25,10 +25,14 @@ type CheckpointInfo struct {
 	UploadedParts []oss.UploadPart `json:"uploaded_parts"` // 已上传的分片列表
 	CreatedAt     time.Time        `json:"created_at"`     // 创建时间
 
-	// 用于恢复续传的非敏感存储信息。临时凭证每次从 API 刷新，不落盘。
-	Bucket   string `json:"bucket,omitempty"`
-	Region   string `json:"region,omitempty"`
-	Endpoint string `json:"endpoint,omitempty"`
+	// 用于恢复续传的凭证与存储信息。checkpoint 文件和所在目录均使用私有权限。
+	Bucket          string `json:"bucket,omitempty"`
+	Region          string `json:"region,omitempty"`
+	Endpoint        string `json:"endpoint,omitempty"`
+	AccessKeyId     string `json:"access_key_id,omitempty"`
+	AccessKeySecret string `json:"access_key_secret,omitempty"`
+	SecurityToken   string `json:"security_token,omitempty"`
+	Expiration      string `json:"expiration,omitempty"` // RFC3339 时间
 }
 
 func cloneCheckpoint(info *CheckpointInfo) *CheckpointInfo {
@@ -99,14 +103,24 @@ func SaveCheckpoint(info *CheckpointInfo) error {
 		return i18n.NewError("error.checkpoint.encode_failed", nil, err)
 	}
 
-	// 写入文件
-	if err := os.WriteFile(checkpointFile, data, 0600); err != nil {
+	// 在写入包含临时凭证的数据前先收紧现有文件权限。os.WriteFile 对已存在
+	// 文件不会应用新的 mode，因此这里与 API Key 文件使用相同的安全写入方式。
+	file, err := os.OpenFile(checkpointFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
 		return i18n.NewError("error.checkpoint.write_failed", map[string]any{"Path": checkpointFile}, err)
 	}
 	if runtime.GOOS != meta.OSWindows {
-		if err := os.Chmod(checkpointFile, 0600); err != nil {
+		if err := file.Chmod(0600); err != nil {
+			_ = file.Close()
 			return i18n.NewError("error.io.permissions_failed", map[string]any{"Path": checkpointFile}, err)
 		}
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return i18n.NewError("error.checkpoint.write_failed", map[string]any{"Path": checkpointFile}, err)
+	}
+	if err := file.Close(); err != nil {
+		return i18n.NewError("error.checkpoint.write_failed", map[string]any{"Path": checkpointFile}, err)
 	}
 
 	logs.Debugf("checkpoint saved: %s\n", checkpointFile)
@@ -153,6 +167,19 @@ func DeleteCheckpoint(checkpointFile string) error {
 
 	logs.Debugf("checkpoint deleted: %s\n", checkpointFile)
 	return nil
+}
+
+// IsCredentialExpired 检查凭证是否过期（提前5分钟判定为过期）。
+func IsCredentialExpired(expiration string) bool {
+	if expiration == "" {
+		return true
+	}
+	expiresAt, err := time.Parse(time.RFC3339, expiration)
+	if err != nil {
+		logs.Warnf("failed to parse credential expiration: %v\n", err)
+		return true
+	}
+	return time.Now().Add(5 * time.Minute).After(expiresAt)
 }
 
 // ValidateCheckpoint 验证checkpoint是否有效（不比对 objectKey，仅校验文件与分片大小）

--- a/lib/checkpoint_test.go
+++ b/lib/checkpoint_test.go
@@ -1,0 +1,50 @@
+package lib
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsCredentialExpired(t *testing.T) {
+	tests := []struct {
+		name       string
+		expiration string
+		want       bool
+	}{
+		{name: "missing", expiration: "", want: true},
+		{name: "invalid", expiration: "not-a-time", want: true},
+		{name: "already expired", expiration: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339), want: true},
+		{name: "inside safety window", expiration: time.Now().Add(4 * time.Minute).UTC().Format(time.RFC3339), want: true},
+		{name: "valid", expiration: time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCredentialExpired(tt.expiration); got != tt.want {
+				t.Fatalf("IsCredentialExpired(%q) = %v, want %v", tt.expiration, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAliOssStorageClientRetainsCheckpointCredentials(t *testing.T) {
+	client, err := NewAliOssStorageClient(
+		"oss-us-east-1.aliyuncs.com",
+		"bucket",
+		"access-key-id",
+		"access-key-secret",
+		"security-token",
+	)
+	if err != nil {
+		t.Fatalf("NewAliOssStorageClient() error = %v", err)
+	}
+
+	expiration := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	client.SetExpiration(expiration)
+	if client.ossAccessKeyId != "access-key-id" ||
+		client.ossAccessKey != "access-key-secret" ||
+		client.ossSecurityToken != "security-token" ||
+		client.ossExpiration != expiration {
+		t.Fatal("OSS client did not retain checkpoint credentials")
+	}
+}

--- a/lib/cover_uploader.go
+++ b/lib/cover_uploader.go
@@ -2,7 +2,6 @@ package lib
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 	"strings"
 
@@ -54,8 +53,10 @@ func UploadCover(client BizyAPI, coverInput string, ctx context.Context, statusC
 	webpPath, webpCleanup, err := ConvertImageToWebPContext(ctx, localPath)
 	convertFailed := false
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return "", err
+		// 只有上传任务本身被取消或超时时才终止；cwebp 下载或转换失败
+		// 只是可选优化失败，给出 warning 并继续上传原始图片。
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
 		}
 		// 转换失败，回退使用原格式（不中断上传）
 		webpPath = localPath

--- a/lib/oss.go
+++ b/lib/oss.go
@@ -19,10 +19,14 @@ import (
 )
 
 type AliOssStorageClient struct {
-	ossClient     ossObjectClient
-	ossBucketName string
-	ossRegion     string
-	ossEndpoint   string
+	ossClient        ossObjectClient
+	ossBucketName    string
+	ossRegion        string
+	ossSecurityToken string
+	ossEndpoint      string
+	ossAccessKeyId   string
+	ossAccessKey     string
+	ossExpiration    string
 }
 
 type ossObjectClient interface {
@@ -67,14 +71,22 @@ func NewAliOssStorageClient(endpoint, bucketName, accessKey, secretKey, security
 	client := oss.NewClient(cfg)
 
 	ossStorageClient := &AliOssStorageClient{
-		ossClient:     client,
-		ossBucketName: bucketName,
-		ossRegion:     region,
-		ossEndpoint:   endpoint,
+		ossClient:        client,
+		ossBucketName:    bucketName,
+		ossRegion:        region,
+		ossSecurityToken: securityToken,
+		ossEndpoint:      endpoint,
+		ossAccessKeyId:   accessKey,
+		ossAccessKey:     secretKey,
 	}
 
 	logs.Debugf("new oss storage client: endpoint=%s bucket=%s region=%s", endpoint, bucketName, region)
 	return ossStorageClient, nil
+}
+
+// SetExpiration 设置当前临时凭证过期时间（用于写入 checkpoint）。
+func (a *AliOssStorageClient) SetExpiration(expiration string) {
+	a.ossExpiration = expiration
 }
 
 func (a *AliOssStorageClient) UploadFile(file *FileToUpload, objectName string, fileIndex string, progress func(int64, int64)) (string, error) {
@@ -257,6 +269,29 @@ func (a *AliOssStorageClient) uploadFileMultipartOnce(
 				objectName = checkpoint.ObjectKey
 				file.RemoteKey = objectName
 			}
+			// 只使用 checkpoint 中尚未过期的
+			// 原始临时凭证，避免新凭证与旧 objectKey/uploadID 混用。
+			if checkpoint.AccessKeyId != "" && checkpoint.AccessKeySecret != "" && !IsCredentialExpired(checkpoint.Expiration) {
+				logs.Debugf("[%s] checkpoint credentials are valid; using cached credentials\n", fileIndex)
+				if cli, credentialErr := NewAliOssStorageClient(
+					checkpoint.Endpoint,
+					checkpoint.Bucket,
+					checkpoint.AccessKeyId,
+					checkpoint.AccessKeySecret,
+					checkpoint.SecurityToken,
+				); credentialErr == nil {
+					a.ossClient = cli.ossClient
+					a.ossBucketName = checkpoint.Bucket
+					a.ossRegion = parseRegionFromEndpoint(checkpoint.Endpoint)
+					a.ossSecurityToken = checkpoint.SecurityToken
+					a.ossEndpoint = checkpoint.Endpoint
+					a.ossAccessKeyId = checkpoint.AccessKeyId
+					a.ossAccessKey = checkpoint.AccessKeySecret
+					a.ossExpiration = checkpoint.Expiration
+				} else {
+					logs.Warnf("[%s] failed to rebuild client from checkpoint credentials: %v\n", fileIndex, credentialErr)
+				}
+			}
 			existingParts = checkpoint.UploadedParts
 		} else if checkpoint != nil {
 			logs.Warnf("[%s] checkpoint validation failed, starting new upload\n", fileIndex)
@@ -279,24 +314,42 @@ func (a *AliOssStorageClient) uploadFileMultipartOnce(
 
 		// 创建新的checkpoint
 		checkpoint = &CheckpointInfo{
-			ObjectKey:     objectName,
-			UploadID:      uploadID,
-			FilePath:      file.Path,
-			FileSize:      totalSize,
-			FileSignature: file.Signature,
-			PartSize:      meta.MultipartPartSize,
-			TotalParts:    (totalSize + meta.MultipartPartSize - 1) / meta.MultipartPartSize,
-			UploadedParts: []oss.UploadPart{},
-			CreatedAt:     time.Now(),
-			Bucket:        a.ossBucketName,
-			Region:        a.ossRegion,
-			Endpoint:      a.ossEndpoint,
+			ObjectKey:       objectName,
+			UploadID:        uploadID,
+			FilePath:        file.Path,
+			FileSize:        totalSize,
+			FileSignature:   file.Signature,
+			PartSize:        meta.MultipartPartSize,
+			TotalParts:      (totalSize + meta.MultipartPartSize - 1) / meta.MultipartPartSize,
+			UploadedParts:   []oss.UploadPart{},
+			CreatedAt:       time.Now(),
+			Bucket:          a.ossBucketName,
+			Region:          a.ossRegion,
+			Endpoint:        a.ossEndpoint,
+			AccessKeyId:     a.ossAccessKeyId,
+			AccessKeySecret: a.ossAccessKey,
+			SecurityToken:   a.ossSecurityToken,
+			Expiration:      a.ossExpiration,
 		}
 		// 保存当前使用的远端key，供上层在提交阶段复用
 		file.RemoteKey = objectName
 		// 立即保存一次 checkpoint（若启用）
 		if checkpointFile != "" {
 			_ = SaveCheckpoint(checkpoint)
+		}
+	} else if checkpoint != nil {
+		// 若调用方传入的凭证发生变化，同步 checkpoint，保持上传会话完整。
+		if checkpoint.AccessKeyId != a.ossAccessKeyId || checkpoint.Expiration != a.ossExpiration {
+			checkpoint.Bucket = a.ossBucketName
+			checkpoint.Region = a.ossRegion
+			checkpoint.Endpoint = a.ossEndpoint
+			checkpoint.AccessKeyId = a.ossAccessKeyId
+			checkpoint.AccessKeySecret = a.ossAccessKey
+			checkpoint.SecurityToken = a.ossSecurityToken
+			checkpoint.Expiration = a.ossExpiration
+			if checkpointFile != "" {
+				_ = SaveCheckpoint(checkpoint)
+			}
 		}
 	}
 

--- a/lib/security_storage_test.go
+++ b/lib/security_storage_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -37,17 +36,21 @@ func TestCredentialAndCheckpointFilesUsePrivatePermissions(t *testing.T) {
 	assertPermission(t, keyPath, 0600)
 
 	checkpoint := &CheckpointInfo{
-		ObjectKey:     "models/test.safetensors",
-		UploadID:      "upload-id",
-		FilePath:      "/tmp/test.safetensors",
-		FileSize:      42,
-		FileSignature: "signature",
-		PartSize:      int64(meta.MultipartPartSize),
-		TotalParts:    1,
-		CreatedAt:     time.Now(),
-		Bucket:        "bucket",
-		Region:        "region",
-		Endpoint:      "endpoint",
+		ObjectKey:       "models/test.safetensors",
+		UploadID:        "upload-id",
+		FilePath:        "/tmp/test.safetensors",
+		FileSize:        42,
+		FileSignature:   "signature",
+		PartSize:        int64(meta.MultipartPartSize),
+		TotalParts:      1,
+		CreatedAt:       time.Now(),
+		Bucket:          "bucket",
+		Region:          "region",
+		Endpoint:        "endpoint",
+		AccessKeyId:     "access-key-id",
+		AccessKeySecret: "access-key-secret",
+		SecurityToken:   "security-token",
+		Expiration:      time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
 	}
 	if err := SaveCheckpoint(checkpoint); err != nil {
 		t.Fatalf("SaveCheckpoint() error = %v", err)
@@ -59,15 +62,22 @@ func TestCredentialAndCheckpointFilesUsePrivatePermissions(t *testing.T) {
 	assertPermission(t, filepath.Dir(checkpointPath), 0700)
 	assertPermission(t, checkpointPath, 0600)
 
-	data, err := os.ReadFile(checkpointPath)
-	if err != nil {
-		t.Fatalf("read checkpoint: %v", err)
+	// Checkpoints now intentionally contain the original temporary credentials
+	// so an interrupted multipart upload can resume with the same authorized
+	// object key. Existing permissive files are repaired before credentials are read.
+	if err := os.Chmod(checkpointPath, 0644); err != nil {
+		t.Fatalf("chmod legacy checkpoint: %v", err)
 	}
-	serialized := strings.ToLower(string(data))
-	for _, secretField := range []string{"access_key", "access_key_secret", "security_token", "expiration"} {
-		if strings.Contains(serialized, secretField) {
-			t.Errorf("checkpoint contains credential field %q: %s", secretField, data)
-		}
+	loaded, err := LoadCheckpoint(checkpointPath)
+	if err != nil {
+		t.Fatalf("LoadCheckpoint() error = %v", err)
+	}
+	assertPermission(t, checkpointPath, 0600)
+	if loaded.AccessKeyId != checkpoint.AccessKeyId ||
+		loaded.AccessKeySecret != checkpoint.AccessKeySecret ||
+		loaded.SecurityToken != checkpoint.SecurityToken ||
+		loaded.Expiration != checkpoint.Expiration {
+		t.Fatal("checkpoint credentials did not round-trip")
 	}
 }
 

--- a/lib/uploader.go
+++ b/lib/uploader.go
@@ -60,8 +60,32 @@ func UnifiedUpload(opts UploadOptions) (string, error) {
 
 	// 4. 如果有有效的 checkpoint，尝试续传
 	if checkpoint != nil && ValidateCheckpoint(checkpoint, opts.File) {
-		logs.Debugf("[%s] valid checkpoint found; refreshing temporary credentials for resume\n", opts.FileIndex)
-		objectKey = checkpoint.ObjectKey
+		logs.Debugf("[%s] valid checkpoint found; preparing to resume\n", opts.FileIndex)
+
+		// 凭证仍有效时复用完整的旧上传会话；
+		// 凭证过期或缺失时丢弃 checkpoint，从零创建新的上传会话。
+		if checkpoint.AccessKeyId != "" && checkpoint.AccessKeySecret != "" && !IsCredentialExpired(checkpoint.Expiration) {
+			cli, credentialErr := NewAliOssStorageClient(
+				checkpoint.Endpoint,
+				checkpoint.Bucket,
+				checkpoint.AccessKeyId,
+				checkpoint.AccessKeySecret,
+				checkpoint.SecurityToken,
+			)
+			if credentialErr == nil {
+				cli.SetExpiration(checkpoint.Expiration)
+				ossClient = cli
+				objectKey = checkpoint.ObjectKey
+			} else {
+				logs.Warnf("[%s] checkpoint credentials could not be restored: %v; refreshing credentials\n", opts.FileIndex, credentialErr)
+			}
+		} else {
+			logs.Warnf("[%s] checkpoint credentials expired or missing; deleting checkpoint and restarting\n", opts.FileIndex)
+			if checkpointFile != "" {
+				_ = DeleteCheckpoint(checkpointFile)
+			}
+			checkpoint = nil
+		}
 	}
 
 	// 5. 如果没有有效的 OSS 客户端，获取新的签名
@@ -100,6 +124,7 @@ func UnifiedUpload(opts UploadOptions) (string, error) {
 		if err != nil {
 			return "", WithStep(i18n.T("step.create_oss_client"), err)
 		}
+		cli.SetExpiration(fileRecord.Expiration)
 		ossClient = cli
 		objectKey = fileRecord.ObjectKey
 	}


### PR DESCRIPTION
## 简介

本次修复提升了模型上传流程的稳定性，重点解决断点续传时临时 OSS 凭证不一致，以及封面 WebP 转换失败导致上传中断的问题。

## 主要改动

- 将临时 OSS 凭证安全保存至 checkpoint，确保分片上传可以恢复原有上传会话。
- 凭证有效时复用断点；凭证缺失、无效或即将过期时清理旧 checkpoint 并重新上传。
- checkpoint 文件使用 `0600` 私有权限，降低临时凭证泄露风险。
- 封面转换 WebP 失败时自动回退上传原始图片；仅在任务取消或超时时终止。
- 补充凭证有效期、凭证恢复及文件权限相关测试。
- 将 macOS `.DS_Store` 加入忽略列表。

## 验证

已执行完整测试：

`go test ./...`

全部通过。